### PR TITLE
Tenant migrations

### DIFF
--- a/apps/ryal_core/config/dev.exs
+++ b/apps/ryal_core/config/dev.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+import_config "../test/support/dummy/config/config.exs"

--- a/apps/ryal_core/config/test.exs
+++ b/apps/ryal_core/config/test.exs
@@ -1,11 +1,3 @@
 use Mix.Config
 
-config :logger, level: :warn
-
-config :mime, :types, %{
-  "application/vnd.api+json" => ["json-api"]
-}
-
-config :phoenix, :format_encoders, "json-api": Poison
-
 import_config "../test/support/dummy/config/config.exs"

--- a/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
+++ b/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.Ryal.Core.Install do
 
   use Mix.Task
 
+  alias Mix.Ecto
+
   def run(_) do
     File.mkdir_p project_migration_dir()
     stamp = String.to_integer timestamp()
@@ -42,7 +44,7 @@ defmodule Mix.Tasks.Ryal.Core.Install do
   defp pad(i), do: to_string(i)
 
   defp project_migration_dir do
-    dir = Mix.Ecto.migrations_path Ryal.repo()
+    dir = Ecto.migrations_path Ryal.repo()
     marketplace? = Application.get_env(:ryal_core, :marketplace)
     if marketplace?, do: marketplace_migrations_folder(dir), else: dir
   end

--- a/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
+++ b/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
@@ -1,0 +1,70 @@
+defmodule Mix.Tasks.Ryal.Core.Install do
+  @moduledoc "Installs all Ryal Core migrations."
+
+  use Mix.Task
+
+  def run(_) do
+    File.mkdir_p project_migration_dir()
+
+    stamp = String.to_integer timestamp()
+
+    ryal_core_migrations()
+    |> Stream.with_index
+    |> Enum.each(fn({ryal_core_migration, index}) ->
+      migration = "#{stamp + index}_#{migration_name(ryal_core_migration)}"
+      copy_migration(ryal_core_migration, project_migration_dir(), migration)
+    end)
+  end
+
+  defp ryal_core_migrations do
+    :ryal_core
+    |> :code.priv_dir
+    |> Path.join("repo/migrations")
+    |> Kernel.<>("/*.exs")
+    |> Path.wildcard
+    |> Enum.reject(&(&1 =~ ~r/ryal_core\.exs$/))
+  end
+
+  defp copy_migration(from, to, file_name) do
+    if migration_exists?(to, file_name) do
+      IO.puts "#{file_name} already exists."
+    else
+      File.cp_r!(from, "#{to}/#{file_name}")
+      IO.puts "Copied #{file_name}"
+    end
+  end
+
+  defp timestamp do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
+  defp pad(i) when i < 10, do: << ?0, ?0 + i >>
+  defp pad(i), do: to_string(i)
+
+  defp migration_exists?(to, file_name) do
+    to
+    <> "/*.exs"
+    |> Path.wildcard
+    |> Enum.map(&get_migration_name/1)
+    |> Enum.member?(get_migration_name file_name)
+  end
+
+  defp project_migration_dir do
+    Mix.Ecto.migrations_path Ryal.repo()
+  end
+
+  defp migration_name(migration) do
+    name = get_migration_name(migration)
+    [name | _] = String.split(name, ".")
+    name <> ".ryal_core.exs"
+  end
+
+  defp get_migration_name(migration) do
+    [<<_d::bytes-size(15)>> <> name | _] = migration
+      |> String.split("/")
+      |> Enum.reverse
+
+    name
+  end
+end

--- a/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
+++ b/apps/ryal_core/lib/mix/tasks/ryal.core.install.ex
@@ -3,8 +3,10 @@ defmodule Mix.Tasks.Ryal.Core.Install do
 
   use Mix.Task
 
+  @project_migration_dir Mix.Ecto.migrations_path(Ryal.repo())
+
   def run(_) do
-    File.mkdir_p project_migration_dir()
+    File.mkdir_p @project_migration_dir
 
     stamp = String.to_integer timestamp()
 
@@ -12,7 +14,7 @@ defmodule Mix.Tasks.Ryal.Core.Install do
     |> Stream.with_index
     |> Enum.each(fn({ryal_core_migration, index}) ->
       migration = "#{stamp + index}_#{migration_name(ryal_core_migration)}"
-      copy_migration(ryal_core_migration, project_migration_dir(), migration)
+      copy_migration(ryal_core_migration, migration)
     end)
   end
 
@@ -25,11 +27,11 @@ defmodule Mix.Tasks.Ryal.Core.Install do
     |> Enum.reject(&(&1 =~ ~r/ryal_core\.exs$/))
   end
 
-  defp copy_migration(from, to, file_name) do
-    if migration_exists?(to, file_name) do
+  defp copy_migration(from, file_name) do
+    if migration_exists?(file_name) do
       IO.puts "#{file_name} already exists."
     else
-      File.cp_r!(from, "#{to}/#{file_name}")
+      File.cp_r!(from, "#{@project_migration_dir}/#{file_name}")
       IO.puts "Copied #{file_name}"
     end
   end
@@ -42,16 +44,12 @@ defmodule Mix.Tasks.Ryal.Core.Install do
   defp pad(i) when i < 10, do: << ?0, ?0 + i >>
   defp pad(i), do: to_string(i)
 
-  defp migration_exists?(to, file_name) do
-    to
+  defp migration_exists?(file_name) do
+    @project_migration_dir
     <> "/*.exs"
     |> Path.wildcard
     |> Enum.map(&get_migration_name/1)
     |> Enum.member?(get_migration_name file_name)
-  end
-
-  defp project_migration_dir do
-    Mix.Ecto.migrations_path Ryal.repo()
   end
 
   defp migration_name(migration) do
@@ -61,7 +59,7 @@ defmodule Mix.Tasks.Ryal.Core.Install do
   end
 
   defp get_migration_name(migration) do
-    [<<_d::bytes-size(15)>> <> name | _] = migration
+    [<<_::bytes-size(15)>> <> name | _] = migration
       |> String.split("/")
       |> Enum.reverse
 

--- a/apps/ryal_core/lib/mix/tasks/ryal.install.ex
+++ b/apps/ryal_core/lib/mix/tasks/ryal.install.ex
@@ -1,0 +1,9 @@
+defmodule Mix.Tasks.Ryal.Install do
+  @moduledoc "Installs all Ryal migrations."
+
+  use Mix.Task
+
+  def run(args) do
+    Mix.Tasks.Ryal.Core.Install.run(args)
+  end
+end

--- a/apps/ryal_core/lib/mix/tasks/ryal.install.ex
+++ b/apps/ryal_core/lib/mix/tasks/ryal.install.ex
@@ -3,7 +3,9 @@ defmodule Mix.Tasks.Ryal.Install do
 
   use Mix.Task
 
+  alias Mix.Tasks.Ryal.Core.Install, as: Core
+
   def run(args) do
-    Mix.Tasks.Ryal.Core.Install.run(args)
+    Core.run(args)
   end
 end

--- a/apps/ryal_core/mix.exs
+++ b/apps/ryal_core/mix.exs
@@ -42,7 +42,7 @@ defmodule Ryal.Core.Mixfile do
 
   defp deps do
     [
-      {:dummy, path: "test/support/dummy", only: :test},
+      {:dummy, path: "test/support/dummy", only: [:dev, :test]},
       {:ecto, "~> 2.1"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:ja_serializer, "~> 0.12"},


### PR DESCRIPTION
I've added two tasks. One is called `ryal.install` and the other is `ryal.core.install`.

`ryal.install` just iterates over all of the packages and calls their relative install task. Helpful.

`ryal.core.install` is particularly meant for Ryal Core, where we actually do the migration copying. We take the name of the migration, attach a new timestamp and add the type of migration to it at the end such as `NEWTIMESTAMP_create_orders.ryal_core.exs`. This way people know where the migration came exactly from. It doesn't really need to act as a namespace for conflict reasons considering we have timestamps.

Anywho, if you rerun the task, we also check if it's already copied. This is especially useful in case you need to alter an existing migration and hope the command won't shatter on you.

Also, we now load up the dummy application in the dev environment to help with testing.

If you're working on building a marketplace, Ryal will now copy migrations to a `tenant_migations` folder or wherever you've configured Apartmentex. No dependency added for it, yet I have a feeling you'll most likely be using something like it if you want to have a marketplace.