### PR TITLE
rename Ryal.UserGateway to Ryal.PaymentGateway

### DIFF
--- a/apps/ryal_core/lib/ryal/web/models/payment_gateway.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_gateway.ex
@@ -1,4 +1,4 @@
-defmodule Ryal.UserGateway do
+defmodule Ryal.PaymentGateway do
   @moduledoc """
   For each gateway that an application is using, we have a profile or record of
   the `User`'s existence on that gateway. Think of it as a join table between a
@@ -7,7 +7,7 @@ defmodule Ryal.UserGateway do
 
   use Ryal.Web, :model
 
-  schema "ryal_user_gateways" do
+  schema "ryal_payment_gateways" do
     field :type, :string
 
     has_many :payment_method_gateways, Ryal.PaymentMethodGateway

--- a/apps/ryal_core/lib/ryal/web/models/payment_method_gateway.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_method_gateway.ex
@@ -10,7 +10,7 @@ defmodule Ryal.PaymentMethodGateway do
   schema "ryal_payment_method_gateways" do
     has_many :payments, Ryal.Payment
 
+    belongs_to :payment_gateway, Ryal.PaymentGateway
     belongs_to :payment_method, Ryal.PaymentMethod
-    belongs_to :user_gateway, Ryal.UserGateway
   end
 end

--- a/apps/ryal_core/priv/repo/migrations/20170225213107_create_ryal_payment_gateways.exs
+++ b/apps/ryal_core/priv/repo/migrations/20170225213107_create_ryal_payment_gateways.exs
@@ -2,7 +2,7 @@ defmodule Ryal.Repo.Migrations.CreateRyalUserGateways do
   use Ecto.Migration
 
   def change do
-    create table(:ryal_user_gateways) do
+    create table(:ryal_payment_gateways) do
       add :type, :string, null: false
 
       add :user_id, references(Ryal.user_table()), null: false

--- a/apps/ryal_core/priv/repo/migrations/20170225213109_create_ryal_payment_method_gateways.exs
+++ b/apps/ryal_core/priv/repo/migrations/20170225213109_create_ryal_payment_method_gateways.exs
@@ -3,8 +3,8 @@ defmodule Ryal.Repo.Migrations.CreateRyalPaymentMethodGateways do
 
   def change do
     create table(:ryal_payment_method_gateways) do
+      add :payment_gateway_id, references(:ryal_payment_gateways), null: false
       add :payment_method_id, references(:ryal_payment_methods), null: false
-      add :user_gateway_id, references(:ryal_user_gateways), null: false
 
       timestamps()
     end

--- a/apps/ryal_core/test/support/dummy/web/models/user.ex
+++ b/apps/ryal_core/test/support/dummy/web/models/user.ex
@@ -6,9 +6,9 @@ defmodule Dummy.User do
   schema "users" do
     field :email, :string
 
-    has_many :payment_methods, Ryal.PaymentMethod
-    has_many :user_gateways, Ryal.UserGateway
     has_many :orders, Ryal.Order
+    has_many :payment_gateways, Ryal.PaymentGateway
+    has_many :payment_methods, Ryal.PaymentMethod
 
     timestamps()
   end


### PR DESCRIPTION
This is my bad. Poor initial naming on my end and I didn't take the time to update before I merged.