### PR TITLE
Credit Cards and Payment Methods

### DIFF
--- a/apps/ryal_core/lib/ryal/web/models/calculators/base33_calculator.ex
+++ b/apps/ryal_core/lib/ryal/web/models/calculators/base33_calculator.ex
@@ -14,7 +14,7 @@ defmodule Ryal.Base33Calculator do
     @characters
     |> Enum.shuffle
     |> Enum.take(count)
-    |> Enum.join()
+    |> Enum.join
   end
 
   @doc """

--- a/apps/ryal_core/lib/ryal/web/models/payment_method.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_method.ex
@@ -2,14 +2,72 @@ defmodule Ryal.PaymentMethod do
   @moduledoc """
   A standard adapter to multiple payment methods.
 
-  TODO: Payment Method documentation as this model becomes more fledged out.
+  You can specify which payment you'd like to use via the `type` field and
+  placing the data of a payment in the `data` field.
+
+  The `data` field uses PostgreSQL's JSONB column to store the dynamic
+  information. We use validations and whatnot at the application level to ensure
+  the data is consistent. (Although, it would be nice is we could add
+  constraints to PG later on.)
+
+  ## Example
+
+      iex> Ryal.PaymentMethod.changeset(%Ryal.PaymentMethod{}, %{
+        type: "credit_card",
+        data: %{
+          name: "Bobby Orr",
+          number: "4242 4242 4242 4242",
+          month: "03",
+          year: "2048",
+          cvc: "004"
+        }
+      })
+
+      #Ecto.Changeset<action: nil,
+       changes: %{data: #Ecto.Changeset<action: :insert,
+          changes: %{cvc: "123", month: "03", name: "Bobby Orr",
+            number: "4242 4242 4242", year: "2048"}, errors: [],
+          data: #Ryal.PaymentMethod.CreditCard<>, valid?: true>,
+          type: "credit_card"},
+       errors: [], data: #Ryal.PaymentMethod<>, valid?: true>
   """
 
   use Ryal.Web, :model
 
   schema "ryal_payment_methods" do
+    field :type, :string
+
+    embeds_one :data, Ryal.PaymentMethod.Proxy
+
     has_many :payment_method_gateways, Ryal.PaymentMethodGateway
 
     belongs_to :user, Ryal.user_module()
   end
+
+  @required_fields ~w(type user_id)a
+  @payment_method_types ~w(credit_card)
+
+  @doc """
+  You hand us some `data` and a `type` and we associate a payment method to a
+  user.
+
+  For an example on how to use this function, see the module description.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(set_module_type(params), @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_inclusion(:type, @payment_method_types)
+    |> cast_embed(:data, required: true)
+  end
+
+  defp set_module_type(%{type: type} = params)
+      when type in @payment_method_types do
+    module_type = Macro.camelize(type)
+    {module_name, []} = Code.eval_string("Ryal.PaymentMethod.#{module_type}")
+    data = Map.get(params, :data, %{})
+    Map.put(params, :data, struct(module_name, data))
+  end
+
+  defp set_module_type(params), do: params
 end

--- a/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
@@ -1,0 +1,55 @@
+defmodule Ryal.PaymentMethod.CreditCard do
+  @moduledoc """
+  Welcome to `Ryal.PaymentMethod.CreditCard`! Here, we store credit cards! OK,
+  not actually...
+
+  Well, we actually just store the information that would be of use for a user
+  and then the actual sensitive data with your payment gateways; the guys with
+  all that bank level security.
+
+  The `month` and `year` are both two digit fields that should come in as
+  strings. CVC is whichever you like it; it's a virtual string field. Finally,
+  that `number` field? It's a string as well. And don't worry about spaces,
+  tabs, or even line endings, we handle that :)
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset, only: [cast: 3, validate_required: 2, put_change: 3]
+
+  embedded_schema do
+    field :name, :string
+
+    field :last_digits, :string
+    field :number, :string, virtual: true
+
+    field :month, :string
+    field :year, :string
+
+    field :cvc, :string, virtual: true
+  end
+
+  @required_fields ~w(name number month year cvc)a
+
+  @doc """
+  Does the usual of what changesets usually do. Except, here we have some magic!
+  We're going to just take the virtual field, number, clean it up, and then
+  store the last four digits.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+    |> cast_number_to_last_digits
+    |> validate_required([:last_digits])
+  end
+
+  defp cast_number_to_last_digits(changeset) do
+    number = Regex.replace(~r/[[:space:]]/, changeset.changes.number, "")
+    {_, digits} = String.split_at(number, -4)
+
+    changeset
+    |> put_change(:number, number)
+    |> put_change(:last_digits, digits)
+  end
+end

--- a/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
@@ -45,11 +45,15 @@ defmodule Ryal.PaymentMethod.CreditCard do
   end
 
   defp cast_number_to_last_digits(changeset) do
-    number = Regex.replace(~r/[[:space:]]/, changeset.changes.number, "")
-    {_, digits} = String.split_at(number, -4)
+    if Map.has_key?(changeset.changes, :number) do
+      number = Regex.replace(~r/[[:space:]]/, changeset.changes.number, "")
+      {_, digits} = String.split_at(number, -4)
 
-    changeset
-    |> put_change(:number, number)
-    |> put_change(:last_digits, digits)
+      changeset
+      |> put_change(:number, number)
+      |> put_change(:last_digits, digits)
+    else
+      changeset
+    end
   end
 end

--- a/apps/ryal_core/lib/ryal/web/models/payment_methods/proxy.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_methods/proxy.ex
@@ -1,0 +1,45 @@
+defmodule Ryal.PaymentMethod.Proxy do
+  @moduledoc """
+  When passing data into a `Ryal.PaymentMethod`, this module detects the struct
+  and uses the appropriate changeset and embedded schema. It's what a proxy
+  does. :D
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset, only: [cast: 3]
+
+  embedded_schema do
+  end
+
+  @doc """
+  This changeset particularly just converts the struct received into a changeset
+  specific to that struct's module.
+
+  If the struct provided is a map (you forgot to specify a `type` for a
+  `Ryal.PaymentMethod`), then we really just return a cast of the proxy.
+
+  We use `map_size/1` here as a guard because both a struct and a map would pass
+  an `is_map/1` check. So, we check the size! Structs have at least `8`, whereas
+  maps can actually reach `0`:
+
+      iex> map_size %CreditCard{}
+      8
+
+      iex> map_size %{}
+      0
+
+  """
+  def changeset(proxy, struct) when map_size(struct) == 0 do
+    cast(proxy, %{}, [])
+  end
+
+  def changeset(_proxy, struct) do
+    %module{} = struct
+    params = Map.from_struct(struct)
+
+    module
+    |> struct(%{})
+    |> module.changeset(params)
+  end
+end

--- a/apps/ryal_core/priv/repo/migrations/20170225213108_create_ryal_payment_methods.exs
+++ b/apps/ryal_core/priv/repo/migrations/20170225213108_create_ryal_payment_methods.exs
@@ -3,6 +3,8 @@ defmodule Ryal.Repo.Migrations.CreateRyalPaymentMethods do
 
   def change do
     create table(:ryal_payment_methods) do
+      add :data, :map, null: false
+
       add :user_id, references(Ryal.user_table()), null: false
 
       timestamps()

--- a/apps/ryal_core/test/models/payment_method_test.exs
+++ b/apps/ryal_core/test/models/payment_method_test.exs
@@ -1,0 +1,27 @@
+defmodule Ryal.PaymentMethodTest do
+  use Ryal.ModelCase, async: true
+
+  alias Ryal.PaymentMethod
+  alias Ryal.PaymentMethod.CreditCard
+
+  describe ".changeset/2" do
+    test "will cast the appropriate data embed" do
+      changeset = PaymentMethod.changeset(%PaymentMethod{}, %{
+          type: "credit_card"
+        })
+
+      %module{} = changeset.changes.data.data
+      assert module == CreditCard
+    end
+
+    test "won't break when a type isn't specified" do
+      changeset = PaymentMethod.changeset(%PaymentMethod{}, %{})
+      refute changeset.valid?
+    end
+
+    test "isn't susceptible to h4ck1ng" do
+      changeset = PaymentMethod.changeset(%PaymentMethod{}, %{type: "proxy"})
+      assert {"is invalid", [validation: :inclusion]} == changeset.errors[:type]
+    end
+  end
+end

--- a/apps/ryal_core/test/models/payment_methods/credit_card_test.exs
+++ b/apps/ryal_core/test/models/payment_methods/credit_card_test.exs
@@ -1,0 +1,55 @@
+defmodule Ryal.PaymentMethod.CreditCardTest do
+  use Ryal.ModelCase, async: true
+
+  alias Ryal.PaymentMethod.CreditCard
+
+  describe ".changeset/2" do
+    setup do
+      [
+        attrs: %{
+          name: "Bobby Orr",
+          number: "4242 4242 4242 4242",
+          month: "03",
+          year: "2048",
+          cvc: "004"
+        }
+      ]
+    end
+
+    test "won't break when there's no number" do
+      refute CreditCard.changeset(%CreditCard{}, %{}).valid?
+    end
+
+    test "will create a new credit card changeset", %{attrs: params} do
+      changeset = CreditCard.changeset(%CreditCard{}, params)
+
+      assert changeset.changes.number == "4242424242424242"
+      assert changeset.changes.last_digits == "4242"
+      assert changeset.valid?
+    end
+
+    test "can use numbers with tabs", %{attrs: params} do
+      params = %{params | number: "4242 4242  4242  4242"}
+      changeset = CreditCard.changeset(%CreditCard{}, params)
+
+      assert changeset.changes.number == "4242424242424242"
+      assert changeset.changes.last_digits == "4242"
+      assert changeset.valid?
+    end
+
+    test "can use numbers with line endings", %{attrs: params} do
+      params = %{params | number: """
+        4242
+        4242
+        4242
+        4242
+        """
+      }
+      changeset = CreditCard.changeset(%CreditCard{}, params)
+
+      assert changeset.changes.number == "4242424242424242"
+      assert changeset.changes.last_digits == "4242"
+      assert changeset.valid?
+    end
+  end
+end

--- a/apps/ryal_core/test/models/payment_methods/proxy_test.exs
+++ b/apps/ryal_core/test/models/payment_methods/proxy_test.exs
@@ -1,0 +1,19 @@
+defmodule Ryal.PaymentMethod.ProxyTest do
+  use Ryal.ModelCase, async: true
+
+  alias Ryal.PaymentMethod.Proxy
+  alias Ryal.PaymentMethod.CreditCard
+
+  describe ".changeset/2" do
+    test "will work with empty maps" do
+      expectation = Ecto.Changeset.cast(%Proxy{}, %{}, [])
+      assert Proxy.changeset(%Proxy{}, %{}) == expectation
+    end
+
+    test "will select changeset based on struct provided" do
+      params = Map.from_struct(%CreditCard{})
+      expectation = CreditCard.changeset(%CreditCard{}, params)
+      assert Proxy.changeset(%Proxy{}, %CreditCard{}) == expectation
+    end
+  end
+end


### PR DESCRIPTION
This PR focuses on setting up a form of convention when creating new payment methods. The problem is that a lot of the data is specific to that model, yet, we also need to be able distinguish and list payment methods simply.

If we have multiple tables - credit_cards, debit_cards, bitcoins - we'll have to do joins onto all of them and hope that we can iron out the inconsistencies. Instead, we use PG 9.4's JSONB type to store all of the specific information and then let Ecto handle all of the validations. It would be great though if we could run the validations onto the DB as well with the JSONB.

To handle the embedded schemas, we've got to have a proxy to mitigate, depending on the payment type, which changeset to apply the params to. To do this, we use a changeset to convert the params from a map to a struct (although technically a struct is map, but you get what I'm saying). Then, once the proxy receives the struct, it can decide, using the struct's module, which changeset it wants to use. Finally, we do the hokey-pokey and we turn our data around.

Anywho, this means that all Payment Methods are nested under a `Ryal.PaymentMethod` namespace. I've taken the time to add a `Ryal.PaymentMethod.CreditCard` in to show how it would work with them.

---

fixes #8 