### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
+dist: trusty
+sudo: false
+
 language: elixir
 otp_release:
   - 19.2
 elixir:
   - 1.4.2
+
+addons:
+  postgresql: "9.6"
+
 install:
   - mix local.hex --force
   - mix local.rebar --force
-  - mix deps.get
+  - mix do deps.get, compile
 before_script:
   - cd apps/ryal_core && mix db.reset && cd ../..
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ otp_release:
 elixir:
   - 1.4.2
 
+cache:
+  directories:
+    - _build
+    - deps
+
 addons:
   postgresql: "9.6"
 


### PR DESCRIPTION
When trying to upgrade PG from 9.1 (TravisCI default) to at least 9.4 I had some connection issues. I chose 9.6 and while doing so, I also had to move the TravisCI dist from precise to trusty. Turned sudo off (I think it was already off, but just to make sure) for a performance boost. I also made sure that we cache the `deps` and `_build` directories. This ended up changing our 4min 20sec builds into 1min 20sec builds; 3 minutes gone!
