### PR TITLE
add the ability to handle ephemeral data

### DIFF
--- a/apps/ryal_core/lib/ryal/web/models/payment_gateways/stripe.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_gateways/stripe.ex
@@ -10,7 +10,7 @@ defmodule Ryal.PaymentGateway.Stripe do
   def create(type, schema, stripe_base \\ @stripe_base)
 
   def create(:credit_card, payment_method, stripe_base) do
-    credit_card_data = payment_method.proxy.data
+    credit_card_data = payment_method.ephemeral
     customer_id = payment_method.user_id
       |> PaymentGatewayQuery.get_external_id("stripe")
       |> Ryal.repo.one!

--- a/apps/ryal_core/lib/ryal/web/models/payment_method.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_method.ex
@@ -3,18 +3,19 @@ defmodule Ryal.PaymentMethod do
   A standard adapter to multiple payment methods.
 
   You can specify which payment you'd like to use via the `type` field and
-  placing the data of a payment in the `data` field.
+  placing the data of a payment in a `data` field.
 
-  The `data` field uses PostgreSQL's JSONB column to store the dynamic
-  information. We use validations and whatnot at the application level to ensure
-  the data is consistent. (Although, it would be nice is we could add
-  constraints to PG later on.)
+  The `data` resides within a `proxy` field which uses PostgreSQL's JSONB column
+  to store the dynamic information. We use validations and whatnot at the
+  application level to ensure the data is consistent. (Although, it would be
+  nice is we could add constraints to PG later on.)
 
   ## Example
 
       iex> Ryal.PaymentMethod.changeset(%Ryal.PaymentMethod{}, %{
         type: "credit_card",
-        data: %{
+        user_id: 1,
+        proxy: %{
           name: "Bobby Orr",
           number: "4242 4242 4242 4242",
           month: "03",
@@ -24,12 +25,13 @@ defmodule Ryal.PaymentMethod do
       })
 
       #Ecto.Changeset<action: nil,
-       changes: %{data: #Ecto.Changeset<action: :insert,
-          changes: %{cvc: "123", month: "03", name: "Bobby Orr",
-            number: "4242 4242 4242 4242", year: "2048"}, errors: [],
-          data: #Ryal.PaymentMethod.CreditCard<>, valid?: true>,
-          type: "credit_card"},
-       errors: [], data: #Ryal.PaymentMethod<>, valid?: true>
+       changes: %{ephemeral: %{cvc: "004", month: "03", name: "Bobby Orr",
+           number: "4242 4242 4242 4242", year: "2048"},
+         proxy: #Ecto.Changeset<action: :insert,
+          changes: %{data: %{last_digits: "4242", month: "03",
+              name: "Bobby Orr", year: "2048"}}, errors: [],
+          data: #Ryal.PaymentMethod.Proxy<>, valid?: true>, type: "credit_card",
+         user_id: 1}, errors: [], data: #Ryal.PaymentMethod<>, valid?: true>
   """
 
   use Ryal.Web, :model
@@ -38,6 +40,7 @@ defmodule Ryal.PaymentMethod do
     field :type, :string
 
     embeds_one :proxy, Ryal.PaymentMethod.Proxy
+    field :ephemeral, :map, virtual: true
 
     has_many :payment_method_gateways, Ryal.PaymentMethodGateway
 
@@ -50,14 +53,14 @@ defmodule Ryal.PaymentMethod do
   @payment_method_types ~w(credit_card)
 
   @doc """
-  You hand us some `data` and a `type` and we associate a payment method to a
-  user.
+  You hand us a `proxy` of data and a `type` and we associate a payment method
+  to a user.
 
   For an example on how to use this function, see the module description.
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(set_module_type(params), @required_fields)
+    |> cast(set_module_type(params), @required_fields ++ [:ephemeral])
     |> validate_required(@required_fields)
     |> validate_inclusion(:type, @payment_method_types)
     |> cast_embed(:proxy, required: true)
@@ -67,8 +70,13 @@ defmodule Ryal.PaymentMethod do
       when type in @payment_method_types do
     module_type = Macro.camelize(type)
     {module_name, []} = Code.eval_string("Ryal.PaymentMethod.#{module_type}")
-    proxy_data = Map.get(params, :proxy, %{})
-    Map.put(params, :proxy, struct(module_name, proxy_data))
+
+    all_data = Map.get(params, :proxy, %{})
+    proxy_data = struct(module_name, all_data)
+
+    params
+    |> Map.put(:proxy, proxy_data)
+    |> Map.put(:ephemeral, all_data)
   end
 
   defp set_module_type(params), do: params

--- a/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_methods/credit_card.ex
@@ -42,6 +42,7 @@ defmodule Ryal.PaymentMethod.CreditCard do
     |> validate_required(@required_fields)
     |> cast_number_to_last_digits
     |> validate_required([:last_digits])
+    |> put_change(:cvc, nil)
   end
 
   defp cast_number_to_last_digits(changeset) do
@@ -50,7 +51,7 @@ defmodule Ryal.PaymentMethod.CreditCard do
       {_, digits} = String.split_at(number, -4)
 
       changeset
-      |> put_change(:number, number)
+      |> put_change(:number, nil)
       |> put_change(:last_digits, digits)
     else
       changeset

--- a/apps/ryal_core/lib/ryal/web/models/payment_methods/proxy.ex
+++ b/apps/ryal_core/lib/ryal/web/models/payment_methods/proxy.ex
@@ -46,6 +46,7 @@ defmodule Ryal.PaymentMethod.Proxy do
     %__MODULE__{}
     |> cast(%{data: params}, [:data])
     |> Map.merge(%{
+      changes: %{data: proxy_changeset.changes},
       errors: proxy_changeset.errors,
       valid?: proxy_changeset.valid?
     })

--- a/apps/ryal_core/test/models/payment_methods/credit_card_test.exs
+++ b/apps/ryal_core/test/models/payment_methods/credit_card_test.exs
@@ -23,7 +23,7 @@ defmodule Ryal.PaymentMethod.CreditCardTest do
     test "will create a new credit card changeset", %{attrs: params} do
       changeset = CreditCard.changeset(%CreditCard{}, params)
 
-      assert changeset.changes.number == "4242424242424242"
+      refute Map.has_key?(changeset.changes, :number)
       assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end
@@ -32,7 +32,7 @@ defmodule Ryal.PaymentMethod.CreditCardTest do
       params = %{params | number: "4242 4242  4242  4242"}
       changeset = CreditCard.changeset(%CreditCard{}, params)
 
-      assert changeset.changes.number == "4242424242424242"
+      refute Map.has_key?(changeset.changes, :number)
       assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end
@@ -47,7 +47,7 @@ defmodule Ryal.PaymentMethod.CreditCardTest do
       }
       changeset = CreditCard.changeset(%CreditCard{}, params)
 
-      assert changeset.changes.number == "4242424242424242"
+      refute Map.has_key?(changeset.changes, :number)
       assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end


### PR DESCRIPTION
When we go to save the payment method, we are also saving the cvc and the number. Let's not do that.